### PR TITLE
Fixed a NullPointerException

### DIFF
--- a/src/main/java/net/canarymod/api/world/blocks/CanaryBlock.java
+++ b/src/main/java/net/canarymod/api/world/blocks/CanaryBlock.java
@@ -48,7 +48,9 @@ public class CanaryBlock implements Block {
 
     @Override
     public short getTypeId() {
-        return type.getId();
+        if(type != null)
+            return type.getId();
+        return 0;
     }
 
     @Override


### PR DESCRIPTION
If the server runs without a map, the console throwed a NullPointerException.
it was becuase the type was null, just added a check if the type is null or not.
