### PR TITLE
Fixed for loop condition in CanarySign.getText()

### DIFF
--- a/src/main/java/net/canarymod/api/world/blocks/CanarySign.java
+++ b/src/main/java/net/canarymod/api/world/blocks/CanarySign.java
@@ -34,7 +34,7 @@ public class CanarySign extends CanaryTileEntity implements Sign {
     @Override
     public String[] getText() {
         String[] strings = new String[4];
-        for (int i = 0 ; i < 5 ; i++) {
+        for (int i = 0 ; i < 4 ; i++) {
             strings[i] = getTileEntity().a[i].getWrapper().getFullText();
         }
         return strings;


### PR DESCRIPTION
Corrected "for (int i = 0 ; i < 5 ; i++)" to "for (int i = 0 ; i < 4 ; i++)", as signs only have 4 lines and i=4 caused an ArrayOutOfBoundsException.
