### PR TITLE
Fix consistency within CanaryDoubleChest

### DIFF
--- a/src/main/java/net/canarymod/api/world/blocks/CanaryDoubleChest.java
+++ b/src/main/java/net/canarymod/api/world/blocks/CanaryDoubleChest.java
@@ -26,6 +26,7 @@ public class CanaryDoubleChest extends CanaryChest implements DoubleChest {
     public CanaryDoubleChest(InventoryLargeChest largechest) {
         super((TileEntityChest) largechest.b);
         this.largechest = largechest;
+        inventory = largechest;
     }
 
     /**


### PR DESCRIPTION
CanaryDoubleChest is constructed with one half of the chest as the inventory, which is necessary for CanaryTileEntity to set the location, but it causes all slot getting and setting operations in the underlying CanaryChest to be limited to the range 0-26.  Resetting the inventory field to equal the InventoryLargeChest fixes the issue.
