### PR TITLE
[FIX] ClassCastException in CanaryScoreboard

### DIFF
--- a/src/main/java/net/canarymod/api/scoreboard/CanaryScoreboard.java
+++ b/src/main/java/net/canarymod/api/scoreboard/CanaryScoreboard.java
@@ -121,7 +121,7 @@ public class CanaryScoreboard implements Scoreboard {
         Collection i = handle.i(((CanaryScoreObjective) scoreObjective).getHandle());
         List<Score> scores = new ArrayList<Score>();
         for (Object o : i) {
-            scores.add((Score) o);
+            scores.add(((net.minecraft.scoreboard.Score) o).getCanaryScore());
         }
         return scores;
     }


### PR DESCRIPTION
fix for:
java.lang.ClassCastException: net.minecraft.scoreboard.Score cannot be cast to net.canarymod.api.scoreboard.Score
	at net.canarymod.api.scoreboard.CanaryScoreboard.getScores(CanaryScoreboard.java:124) ~[canary.jar:1.8.0-1.2.1-SNAPSHOT]`